### PR TITLE
Fix container name to be 'akka-sample-cluster-docker-compose-scala'

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ dockerExposedPorts in Docker := Seq(1600)
 dockerEntrypoint in Docker := Seq("sh", "-c", "bin/clustering $*")
 
 dockerRepository := Some("lightbend")
+name := "akka-sample-cluster-docker-compose-scala"
 
 dockerBaseImage := "java"
 enablePlugins(JavaAppPackaging)


### PR DESCRIPTION
Resolves issue with container name not being set and being based on current folder instead (#26)