### PR TITLE
remove outdated bin/clustering entrypoint, clean up whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ In SBT, just run `docker:publishLocal` to create a local docker container.
 
 To run the cluster, run `docker-compose up`. This will create 3 nodes, a seed and two regular members, called `seed`, `c1`, and `c2` respectively.
 
-While running, try opening a new terminal and (from the same directory) try things like `docker-compose down seed` and watch the cluster nodes respond.
+While running, try opening a new terminal and (from the same directory) try things like `docker-compose stop seed` and watch the cluster nodes respond.

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,6 @@
+name := "akka-sample-cluster-docker-compose-scala"
+maintainer := "Michael Hamrah <m@hamrah.com>"
+
 /* scala versions and options */
 scalaVersion := "2.12.7"
 
@@ -23,16 +26,8 @@ libraryDependencies ++= Seq (
 
 )
 
-maintainer := "Michael Hamrah <m@hamrah.com>"
-
 version in Docker := "latest"
-
 dockerExposedPorts in Docker := Seq(1600)
-
-dockerEntrypoint in Docker := Seq("sh", "-c", "bin/clustering $*")
-
 dockerRepository := Some("lightbend")
-name := "akka-sample-cluster-docker-compose-scala"
-
 dockerBaseImage := "java"
 enablePlugins(JavaAppPackaging)


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

Removes outdated bin/clustering docker entrypoint. Also includes some minor build.sbt cleanup.

## References

First discussed in commit df1232183e43c72c34315cae203013baf0615f7e

## Changes

See above

## Background Context

When trying to understand this project locally, the presence of bin/clustering was confusing until it became clear it was outdated code from a previous revision. I am not sure why bin/clustering was initially required. Perhaps a later version of sbt-native-packager made it redundant.
